### PR TITLE
Optimize screamreader audio latency and volume bug

### DIFF
--- a/Receivers/dotnet-windows/ScreamReader/ScreamReader/UdpWaveStreamPlayer.cs
+++ b/Receivers/dotnet-windows/ScreamReader/ScreamReader/UdpWaveStreamPlayer.cs
@@ -1,4 +1,4 @@
-﻿using NAudio.Wave;
+using NAudio.Wave;
 using NAudio.CoreAudioApi;      // For MMDeviceEnumerator & IMMNotificationClient
 using System;
 using System.Diagnostics;
@@ -23,7 +23,7 @@ namespace ScreamReader
 
         private MMDeviceEnumerator deviceEnumerator; // For default device change notifications
 
-        private int volume;
+        private int volume = 100; // Default volume at 100%
 
         // Fields to store constructor parameters
         protected int BitWidth { get; set; }
@@ -136,7 +136,7 @@ namespace ScreamReader
                     var rsws = new BufferedWaveProvider(
                         new WaveFormat(this.SampleRate, this.BitWidth, this.ChannelCount))
                     {
-                        BufferDuration = TimeSpan.FromMilliseconds(100),
+                        BufferDuration = TimeSpan.FromMilliseconds(20),
                         DiscardOnBufferOverflow = true
                     };
 
@@ -173,7 +173,7 @@ namespace ScreamReader
 
                                 rsws = new BufferedWaveProvider(new WaveFormat(newRate, currentWidth, currentChannels))
                                 {
-                                    BufferDuration = TimeSpan.FromMilliseconds(100),
+                                    BufferDuration = TimeSpan.FromMilliseconds(20),
                                     DiscardOnBufferOverflow = true
                                 };
 
@@ -266,7 +266,7 @@ namespace ScreamReader
             using (var mmDeviceEnum = new MMDeviceEnumerator())
             {
                 var device = mmDeviceEnum.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
-                this.output = new WasapiOut(device, AudioClientShareMode.Shared, false, 100);
+                this.output = new WasapiOut(device, AudioClientShareMode.Shared, false, 20);
             }
 
             this.currentWaveProvider = waveProvider;


### PR DESCRIPTION
Fix volume resetting to 0% and reduce audio playback latency from 100ms to 20ms.

The `volume` variable was uninitialized, leading to a default value of 0% on startup or device change. Audio latency was high due to `BufferDuration` and `WasapiOut` being set to 100ms, which is unsuitable for real-time audio streaming.

---
<a href="https://cursor.com/background-agent?bcId=bc-46c465fa-4ecb-4a33-9956-df14ee4e0786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-46c465fa-4ecb-4a33-9956-df14ee4e0786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

